### PR TITLE
Catch `Net::SCP::Error` exceptions and print messages to STDERR.

### DIFF
--- a/bin/ey-scp
+++ b/bin/ey-scp
@@ -93,7 +93,11 @@ end
 servers = instances.map{ |inst| inst['public_hostname'] }
 
 #time to do the copying!
-servers.each do |server| 
-  puts "Uploading to #{server}..."
-  Net::SCP.upload!(server, 'deploy', options[:source], options[:destination] ) 
+servers.each do |server|
+  begin
+    puts "Uploading to #{server}..."
+    Net::SCP.upload!(server, 'deploy', options[:source], options[:destination] )
+  rescue Net::SCP::Error => ex
+    STDERR.puts "Error uploading to #{server}: #{ex.message}"
+  end
 end

--- a/ey-scp.gemspec
+++ b/ey-scp.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 Gem::Specification.new do |spec|
   spec.name          = "ey-scp"
-  spec.version       = '0.3.0'
+  spec.version       = '0.3.1'
   spec.authors       = ["Steven Dunlap"]
   spec.email         = ["steven@roadtrippers.com"]
   spec.description   = "Quickly copy files (e.g. YMLs or configuration files) to multiple EngineYard servers"


### PR DESCRIPTION
Sometimes, a directory may exist on some EY instances, but not all
of them. For example, a Rails app may be installed on app servers
and utility servers, but not the DB servers. Depending on the order
that `ey-scp` chooses to iterate through the server list, it might
try (and fail) to push a Rails configuration file (for example) to
a DB server before it has copied the file to all of the servers that
need it. Before, this would result in some of the servers receiving
the file, while others fail to receive it. Now, failure to copy a
file to one EY instance will not stop the gem from copying the file
to the other, remaining instances.